### PR TITLE
Move default preview callback into constructor to mirror the file field.

### DIFF
--- a/src/Audio.php
+++ b/src/Audio.php
@@ -18,14 +18,14 @@ class Audio extends File
 
     public $showOnIndex = true;
 
-    public function preview(callable $previewUrlCallback)
+    public function __construct(string $name, ?string $attribute = null, ?string $disk = 'public', ?callable $storageCallback = null)
     {
-        $this->previewUrlCallback = function(){
+        parent::__construct($name, $attribute, $disk, $storageCallback);
+
+        $this->preview(function() {
             return $this->value
                 ? Storage::disk($this->disk)->url($this->value)
                 : null;
-        };
-
-        return $this;
+        });
     }
 }

--- a/src/Audio.php
+++ b/src/Audio.php
@@ -18,7 +18,7 @@ class Audio extends File
 
     public $showOnIndex = true;
 
-    public function __construct(string $name, ?string $attribute = null, ?string $disk = 'public', ?callable $storageCallback = null)
+    public function __construct($name, $attribute = null, $disk = 'public', $storageCallback = null)
     {
         parent::__construct($name, $attribute, $disk, $storageCallback);
 


### PR DESCRIPTION
Overwriting the `preview` method in the Audio class prevents the field preview from [being customized](https://nova.laravel.com/docs/1.0/resources/file-fields.html#customization). Following the example of the File class, the default preview method should be defined in constructor.